### PR TITLE
feat: adds variables, colors, dynamic editor, help to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,45 +1,87 @@
 #!/bin/sh
 
-# Automated script to install my dotfiles
+# Color codes for formatted output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No color
 
-# Clone dotfiles
-if [ $# -gt 0 ]
-  then
-    SCRIPT_DIR=$1
-  else
-    SCRIPT_DIR=~/.dotfiles
-fi
-nix-shell -p git --command "git clone https://gitlab.com/librephoenix/nixos-config $SCRIPT_DIR"
+# Default parameters
+SCRIPT_DIR="${HOME}/.dotfiles"
+USER_EMAIL=""
+SKIP_REVIEW=0
+EDITOR="${EDITOR:-nano}"  # Default to nano if EDITOR is not set
 
-# Generate hardware config for new system
-sudo nixos-generate-config --show-hardware-config > $SCRIPT_DIR/system/hardware-configuration.nix
+# Helper function to display usage message
+show_help() {
+  printf "${CYAN}Usage:${NC} $0 [OPTIONS]\n\n"
+  printf "Options:\n"
+  printf "  -d, --directory <path>     Specify the directory to clone the dotfiles (default: ~/.dotfiles)\n"
+  printf "  -e, --email <email>        Provide an email to use for configuration (default: empty)\n"
+  printf "  -y, --yes                  Skip editor confirmation for flake.nix review\n"
+  printf "  -h, --help                 Show this help message\n"
+  exit 0
+}
 
-# Check if uefi or bios
+# Parse arguments
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -d|--directory) SCRIPT_DIR="$2"; shift 2;;
+    -e|--email) USER_EMAIL="$2"; shift 2;;
+    -y|--yes) SKIP_REVIEW=1; shift;;
+    -h|--help) show_help;;
+    --) shift; break;;
+    *) printf "${RED}Error:${NC} Unknown option: $1\n"; show_help; exit 1;;
+  esac
+done
+
+# Clone dotfiles repository
+printf "${CYAN}Cloning dotfiles to ${SCRIPT_DIR}...${NC}\n"
+nix-shell -p git --command "git clone https://gitlab.com/librephoenix/nixos-config $SCRIPT_DIR" || { printf "${RED}Failed to clone repository.${NC}\n"; exit 1; }
+
+# Generate hardware configuration
+printf "${CYAN}Generating hardware configuration...${NC}\n"
+sudo nixos-generate-config --show-hardware-config > "$SCRIPT_DIR/system/hardware-configuration.nix"
+
+# Determine boot mode (UEFI or BIOS) and set flake.nix accordingly
 if [ -d /sys/firmware/efi/efivars ]; then
-    sed -i "0,/bootMode.*=.*\".*\";/s//bootMode = \"uefi\";/" $SCRIPT_DIR/flake.nix
+  printf "${GREEN}Detected UEFI boot mode.${NC}\n"
+  sed -i "0,/bootMode.*=.*\".*\";/s//bootMode = \"uefi\";/" "$SCRIPT_DIR/flake.nix"
 else
-    sed -i "0,/bootMode.*=.*\".*\";/s//bootMode = \"bios\";/" $SCRIPT_DIR/flake.nix
-    grubDevice=$(findmnt / | awk -F' ' '{ print $2 }' | sed 's/\[.*\]//g' | tail -n 1 | lsblk -no pkname | tail -n 1 )
-    sed -i "0,/grubDevice.*=.*\".*\";/s//grubDevice = \"\/dev\/$grubDevice\";/" $SCRIPT_DIR/flake.nix
+  printf "${GREEN}Detected BIOS boot mode.${NC}\n"
+  sed -i "0,/bootMode.*=.*\".*\";/s//bootMode = \"bios\";/" "$SCRIPT_DIR/flake.nix"
+  grubDevice=$(findmnt / | awk '{ print $2 }' | sed 's/\[.*\]//g' | tail -n 1 | lsblk -no pkname | tail -n 1)
+  sed -i "0,/grubDevice.*=.*\".*\";/s//grubDevice = \"\/dev\/$grubDevice\";/" "$SCRIPT_DIR/flake.nix"
 fi
 
-# Patch flake.nix with different username/name and remove email by default
-sed -i "0,/emmet/s//$(whoami)/" $SCRIPT_DIR/flake.nix
-sed -i "0,/Emmet/s//$(getent passwd $(whoami) | cut -d ':' -f 5 | cut -d ',' -f 1)/" $SCRIPT_DIR/flake.nix
-sed -i "s/emmet@librephoenix.com//" $SCRIPT_DIR/flake.nix
-sed -i "s+~/.dotfiles+$SCRIPT_DIR+g" $SCRIPT_DIR/flake.nix
-
-# Open up editor to manually edit flake.nix before install
-if [ -z "$EDITOR" ]; then
-    EDITOR=nano;
+# Customize flake.nix with user information
+printf "${CYAN}Setting user-specific information in flake.nix...${NC}\n"
+sed -i "0,/emmet/s//$(whoami)/" "$SCRIPT_DIR/flake.nix"
+sed -i "0,/Emmet/s//$(getent passwd $(whoami) | cut -d ':' -f 5 | cut -d ',' -f 1)/" "$SCRIPT_DIR/flake.nix"
+if [ -n "$USER_EMAIL" ]; then
+  sed -i "s/emmet@librephoenix.com/$USER_EMAIL/" "$SCRIPT_DIR/flake.nix"
+else
+  sed -i "s/emmet@librephoenix.com//" "$SCRIPT_DIR/flake.nix"
 fi
-$EDITOR $SCRIPT_DIR/flake.nix;
+sed -i "s+~/.dotfiles+$SCRIPT_DIR+g" "$SCRIPT_DIR/flake.nix"
 
-# Permissions for files that should be owned by root
-sudo $SCRIPT_DIR/harden.sh $SCRIPT_DIR;
+# Optional review of flake.nix
+if [ "$SKIP_REVIEW" -eq 0 ]; then
+  printf "${YELLOW}Opening flake.nix for manual review with ${EDITOR}...${NC}\n"
+  $EDITOR "$SCRIPT_DIR/flake.nix"
+fi
 
-# Rebuild system
-sudo nixos-rebuild switch --flake $SCRIPT_DIR#system;
+# Apply security hardening
+printf "${CYAN}Applying security hardening...${NC}\n"
+sudo "$SCRIPT_DIR/harden.sh" "$SCRIPT_DIR"
 
-# Install and build home-manager configuration
-nix run home-manager/master --extra-experimental-features nix-command --extra-experimental-features flakes -- switch --flake $SCRIPT_DIR#user;
+# Rebuild system with new configuration
+printf "${CYAN}Rebuilding system with nixos-rebuild...${NC}\n"
+sudo nixos-rebuild switch --flake "$SCRIPT_DIR#system"
+
+# Build and switch to the user's home-manager configuration
+printf "${CYAN}Setting up home-manager configuration...${NC}\n"
+nix run home-manager/master --extra-experimental-features nix-command --extra-experimental-features flakes -- switch --flake "$SCRIPT_DIR#user"
+
+printf "${GREEN}Installation and configuration complete!${NC}\n"

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ DISABLE_HARDEN=0
 TEMP_CLONE=0
 SKIP_CLONE=0
 SKIP_EMAIL=0
+AUTO_CONFIRM=0
 EDITOR="${EDITOR:-nano}"  # Default to nano if EDITOR is not set
 
 # Helper function to display usage message
@@ -28,6 +29,7 @@ show_help() {
   printf "  -t, --temp-clone           Clone into a temporary directory\n"
   printf "  -s, --skip-clone           Skip the cloning step if directory exists\n"
   printf "  -se, --skip-email          Skip the email replacement step in flake.nix\n"
+  printf "  -ac, --auto-confirm        Automatically confirm the system rebuild\n"
   printf "  -h, --help                 Show this help message\n"
   exit 0
 }
@@ -47,6 +49,7 @@ while [ "$#" -gt 0 ]; do
     -t|--temp-clone) TEMP_CLONE=1; shift;;
     -s|--skip-clone) SKIP_CLONE=1; shift;;
     -se|--skip-email) SKIP_EMAIL=1; shift;;
+    -ac|--auto-confirm) AUTO_CONFIRM=1; shift;;
     -h|--help) show_help;;
     --) shift; break;;
     *) printf "${RED}Error:${NC} Unknown option: $1\n"; show_help; exit 1;;
@@ -115,11 +118,13 @@ else
 fi
 
 # Confirmation prompt for system rebuild
-printf "${YELLOW}Ready to rebuild the system with nixos-rebuild. Do you want to proceed? (y/n) ${NC}"
-read -r confirm
-if [ "$confirm" != "y" ]; then
-  printf "${RED}Aborting system rebuild.${NC}\n"
-  exit 0
+if [ "$AUTO_CONFIRM" -eq 0 ]; then
+  printf "${YELLOW}Ready to rebuild the system with nixos-rebuild. Do you want to proceed? (y/n) ${NC}"
+  read -r confirm
+  if [ "$confirm" != "y" ]; then
+    printf "${RED}Aborting system rebuild.${NC}\n"
+    exit 0
+  fi
 fi
 
 # Rebuild system with new configuration

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ SCRIPT_DIR="${HOME}/.dotfiles"
 USER_EMAIL=""
 SKIP_REVIEW=0
 DISABLE_HARDEN=0
+TEMP_CLONE=0
 EDITOR="${EDITOR:-nano}"  # Default to nano if EDITOR is not set
 
 # Helper function to display usage message
@@ -22,9 +23,15 @@ show_help() {
   printf "  -e, --email <email>        Provide an email to use for configuration (default: empty)\n"
   printf "  -y, --yes                  Skip editor confirmation for flake.nix review\n"
   printf "  -n, --no-harden            Skip the security hardening step\n"
+  printf "  -t, --temp-clone           Clone into a temporary directory\n"
   printf "  -h, --help                 Show this help message\n"
   exit 0
 }
+
+# Check dependencies
+command -v nix-shell >/dev/null 2>&1 || { printf "${RED}Error: nix-shell is not installed.${NC}\n"; exit 1; }
+command -v nixos-rebuild >/dev/null 2>&1 || { printf "${RED}Error: nixos-rebuild is not installed.${NC}\n"; exit 1; }
+command -v nix >/dev/null 2>&1 || { printf "${RED}Error: nix is not installed.${NC}\n"; exit 1; }
 
 # Parse arguments
 while [ "$#" -gt 0 ]; do
@@ -33,6 +40,7 @@ while [ "$#" -gt 0 ]; do
     -e|--email) USER_EMAIL="$2"; shift 2;;
     -y|--yes) SKIP_REVIEW=1; shift;;
     -n|--no-harden) DISABLE_HARDEN=1; shift;;
+    -t|--temp-clone) TEMP_CLONE=1; shift;;
     -h|--help) show_help;;
     --) shift; break;;
     *) printf "${RED}Error:${NC} Unknown option: $1\n"; show_help; exit 1;;
@@ -40,12 +48,17 @@ while [ "$#" -gt 0 ]; do
 done
 
 # Clone dotfiles repository
-printf "${CYAN}Cloning dotfiles to ${SCRIPT_DIR}...${NC}\n"
+if [ "$TEMP_CLONE" -eq 1 ]; then
+  SCRIPT_DIR=$(mktemp -d)
+  printf "${YELLOW}Cloning dotfiles to temporary directory ${SCRIPT_DIR}...${NC}\n"
+else
+  printf "${CYAN}Cloning dotfiles to ${SCRIPT_DIR}...${NC}\n"
+fi
 nix-shell -p git --command "git clone https://gitlab.com/librephoenix/nixos-config $SCRIPT_DIR" || { printf "${RED}Failed to clone repository.${NC}\n"; exit 1; }
 
 # Generate hardware configuration
 printf "${CYAN}Generating hardware configuration...${NC}\n"
-sudo nixos-generate-config --show-hardware-config > "$SCRIPT_DIR/system/hardware-configuration.nix"
+sudo nixos-generate-config --show-hardware-config > "$SCRIPT_DIR/system/hardware-configuration.nix" || { printf "${RED}Failed to generate hardware configuration.${NC}\n"; exit 1; }
 
 # Determine boot mode (UEFI or BIOS) and set flake.nix accordingly
 if [ -d /sys/firmware/efi/efivars ]; then
@@ -78,17 +91,25 @@ fi
 # Apply security hardening if enabled
 if [ "$DISABLE_HARDEN" -eq 0 ]; then
   printf "${CYAN}Applying security hardening...${NC}\n"
-  sudo "$SCRIPT_DIR/harden.sh" "$SCRIPT_DIR"
+  sudo "$SCRIPT_DIR/harden.sh" "$SCRIPT_DIR" || { printf "${RED}Hardening failed.${NC}\n"; exit 1; }
 else
   printf "${YELLOW}Skipping security hardening as requested.${NC}\n"
 fi
 
+# Confirmation prompt for system rebuild
+printf "${YELLOW}Ready to rebuild the system with nixos-rebuild. Do you want to proceed? (y/n) ${NC}"
+read -r confirm
+if [ "$confirm" != "y" ]; then
+  printf "${RED}Aborting system rebuild.${NC}\n"
+  exit 0
+fi
+
 # Rebuild system with new configuration
 printf "${CYAN}Rebuilding system with nixos-rebuild...${NC}\n"
-sudo nixos-rebuild switch --flake "$SCRIPT_DIR#system"
+sudo nixos-rebuild switch --flake "$SCRIPT_DIR#system" || { printf "${RED}System rebuild failed.${NC}\n"; exit 1; }
 
 # Build and switch to the user's home-manager configuration
 printf "${CYAN}Setting up home-manager configuration...${NC}\n"
-nix run home-manager/master --extra-experimental-features nix-command --extra-experimental-features flakes -- switch --flake "$SCRIPT_DIR#user"
+nix run home-manager/master --extra-experimental-features nix-command --extra-experimental-features flakes -- switch --flake "$SCRIPT_DIR#user" || { printf "${RED}Home-manager setup failed.${NC}\n"; exit 1; }
 
 printf "${GREEN}Installation and configuration complete!${NC}\n"

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@ NC='\033[0m' # No color
 SCRIPT_DIR="${HOME}/.dotfiles"
 USER_EMAIL=""
 SKIP_REVIEW=0
+DISABLE_HARDEN=0
 EDITOR="${EDITOR:-nano}"  # Default to nano if EDITOR is not set
 
 # Helper function to display usage message
@@ -20,6 +21,7 @@ show_help() {
   printf "  -d, --directory <path>     Specify the directory to clone the dotfiles (default: ~/.dotfiles)\n"
   printf "  -e, --email <email>        Provide an email to use for configuration (default: empty)\n"
   printf "  -y, --yes                  Skip editor confirmation for flake.nix review\n"
+  printf "  -n, --no-harden            Skip the security hardening step\n"
   printf "  -h, --help                 Show this help message\n"
   exit 0
 }
@@ -30,6 +32,7 @@ while [ "$#" -gt 0 ]; do
     -d|--directory) SCRIPT_DIR="$2"; shift 2;;
     -e|--email) USER_EMAIL="$2"; shift 2;;
     -y|--yes) SKIP_REVIEW=1; shift;;
+    -n|--no-harden) DISABLE_HARDEN=1; shift;;
     -h|--help) show_help;;
     --) shift; break;;
     *) printf "${RED}Error:${NC} Unknown option: $1\n"; show_help; exit 1;;
@@ -72,9 +75,13 @@ if [ "$SKIP_REVIEW" -eq 0 ]; then
   $EDITOR "$SCRIPT_DIR/flake.nix"
 fi
 
-# Apply security hardening
-printf "${CYAN}Applying security hardening...${NC}\n"
-sudo "$SCRIPT_DIR/harden.sh" "$SCRIPT_DIR"
+# Apply security hardening if enabled
+if [ "$DISABLE_HARDEN" -eq 0 ]; then
+  printf "${CYAN}Applying security hardening...${NC}\n"
+  sudo "$SCRIPT_DIR/harden.sh" "$SCRIPT_DIR"
+else
+  printf "${YELLOW}Skipping security hardening as requested.${NC}\n"
+fi
 
 # Rebuild system with new configuration
 printf "${CYAN}Rebuilding system with nixos-rebuild...${NC}\n"


### PR DESCRIPTION
I was reading your install.org and saw `I’ll eventually™ add the ability to supply arguments to this script as well.` so I want to say thank you for your work and try to help. Therefore, I added the following:

**Argument Parsing**
   - Added options `-d`, `-e`, `-y`, `-n`, and `-h` to allow the user to:
     - Specify a custom directory for cloning (`--directory`).
     - Set a user email for `flake.nix` configuration (`--email`).
     - Skip the editor review of `flake.nix` (`--yes`).
     - Skip the security hardening step (`--no-harden`).
     - Display a help message (`--help`).

**Colorful and Consistent Output with `printf`**
   - Introduced color-coded messages using `printf` for different types of output:
     - **Cyan** for informational messages.
     - **Green** for success or status updates.
     - **Yellow** for review prompts.
     - **Red** for error messages.

**Configurable Default Text Editor**
   - Set a configurable `EDITOR` variable with `nano` as the default, allowing users to define their preferred editor by setting the `EDITOR` environment variable.

**Informative and Friendly Help Message**
   - Added a `show_help` function to print detailed usage information:

```bash
Usage: ./install.sh [OPTIONS]

Options:
  -d, --directory <path>     Specify the directory to clone the dotfiles (default: ~/.dotfiles)
  -e, --email <email>        Provide an email to use for configuration (default: empty)
  -y, --yes                  Skip editor confirmation for flake.nix review
  -h, --help                 Show this help message
```

To be honest, I didn't test it yet, need to put in a vm.
Thank you for all your youtube videos and this :)

Marcelo
